### PR TITLE
stop STARTING and CONTRIBUTOR from showing up in tab-completion

### DIFF
--- a/src/main/java/aurilux/titles/common/command/sub/CommandAddRemoveType.java
+++ b/src/main/java/aurilux/titles/common/command/sub/CommandAddRemoveType.java
@@ -26,9 +26,17 @@ public class CommandAddRemoveType {
 
     public static ArgumentBuilder<CommandSourceStack, ?> register() {
         return Commands.argument("commandtype", EnumArgument.enumArgument(CommandType.class))
-                .requires(s -> s.hasPermission(0))
+                .requires(s -> s.hasPermission(2))
                 .then(Commands.argument("player", EntityArgument.player())
                         .then(Commands.argument("awards", EnumArgument.enumArgument(Title.AwardType.class))
+                        .suggests((ctx, builder) -> {
+                            for (Title.AwardType type : Title.AwardType.values()) {
+                                if (type != Title.AwardType.STARTING && type != Title.AwardType.CONTRIBUTOR) {
+                                    builder.suggest(type.name());
+                                }
+                            }
+                            return builder.buildFuture();
+                        })
                         .executes(ctx -> run(ctx,
                                 ctx.getArgument("commandtype", CommandType.class),
                                 EntityArgument.getPlayer(ctx, "player"),
@@ -50,7 +58,7 @@ public class CommandAddRemoveType {
                     cap.add(TitleManager.getTitle(title.getID()));
                     response[0] = Component.translatable("commands.titles.addtype", award.toString(), player.getName());
                 }
-                else { //command == CommandType.removetype
+                else if (command == CommandType.removetype) {
                     TitlesMod.LOG.debug("Removing title type {}", award);
                     cap.remove(TitleManager.getTitle(title.getID()));
                     response[0] = Component.translatable("commands.titles.removetype", award.toString(), player.getName());


### PR DESCRIPTION
it doesn't show them when you try to tab-complete, but they are still there, you just have to manually type their names if you want to use them
<img width="354" height="145" alt="Screenshot 2025-08-20 222227" src="https://github.com/user-attachments/assets/aab9c57f-be24-4d10-8069-ca1fb9313b0e" />
<img width="373" height="96" alt="Screenshot 2025-08-20 223511" src="https://github.com/user-attachments/assets/b6200ac0-7d77-47de-b03d-f49f53cd87dc" />
